### PR TITLE
Support unpickling instances having a numeric timezone like +0430.

### DIFF
--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -786,7 +786,11 @@ class DateTime(object):
                 # Seconds from epoch (gmt) and timezone
                 t, tz = args
                 ms = (t - math.floor(t))
-                tz = _TZINFO._zmap[tz.lower()]
+                try:
+                    tz = _TZINFO._zmap[tz.lower()]
+                except KeyError:
+                    if numericTimeZoneMatch(tz) is None:
+                        raise DateTimeError('Unknown time zone: %s' % tz)
                 # Use integer arithmetic as much as possible.
                 s, d = _calcSD(t)
                 x = _calcDependentSecond(tz, t)

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -232,6 +232,16 @@ class DateTimeTests(unittest.TestCase):
         for key in DateTime.__slots__:
             self.assertEqual(getattr(dt, key), getattr(new, key))
 
+    def test_pickle_with_numerical_tz(self):
+        for dt_str in ('2007/01/02 12:34:56.789 +0300',
+                       '2007/01/02 12:34:56.789 +0430',
+                       '2007/01/02 12:34:56.789 -1234'):
+            dt = DateTime(dt_str)
+            data = pickle.dumps(dt, 1)
+            new = pickle.loads(data)
+            for key in DateTime.__slots__:
+                self.assertEqual(getattr(dt, key), getattr(new, key))
+
     def test_pickle_with_micros(self):
         dt = DateTime('2002/5/2 8:00:14.123 GMT+8')
         data = pickle.dumps(dt, 1)


### PR DESCRIPTION
To fix error in unpickling DateTime object having '+NNNN' timezone #3.