### PR TITLE
Allow driving buildout from tox.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ parts
 *.pyc
 *.pyo
 *.so
-.installed.cfg
+.installed*.cfg
 develop-eggs/
 eggs/
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
     - pip install -U setuptools
     - pip install zc.buildout
     - buildout bootstrap
-    - buildout
+    - buildout tox:env=travis install test
 script:
-    - bin/test -v1
+    - bin/test-travis -v1
 notifications:
     email: false
 cache:

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,16 +1,26 @@
 [buildout]
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 develop = .
 parts = interpreter test
+installed = .installed-${tox:env}.cfg
 
+[versions]
+DateTime =
+
+[tox]
+env = py27
+
+# 'buildout install tox-runner' if you don't have tox installed
+[tox-runner]
+recipe = zc.recipe.egg
+eggs = tox
 
 [interpreter]
 recipe = zc.recipe.egg
-interpreter = python
-eggs =
-    DateTime
-    tox
-
+interpreter = ${tox:env}
+eggs = DateTime
 
 [test]
 recipe = zc.recipe.testrunner
 eggs = DateTime
+script = test-${tox:env}

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,11 @@
 [tox]
 envlist =
-    py27,py34,py35,py36,pypy,pypy3,coverage
+    py27,py34,py35,py36,pypy,pypy3
 
 [testenv]
 commands =
-    zope-testrunner --test-path={envsitepackagesdir} -s DateTime
+    buildout -c {toxinidir}/buildout.cfg tox:env={envname}
+    {toxinidir}/bin/test-{envname}
+skip_install = true
 deps =
-    zope.testrunner
-
-[testenv:coverage]
-basepython =
-    python2.7
-commands =
-    nosetests --with-xunit --with-xcoverage --where={envsitepackagesdir}/DateTime --cover-package=DateTime
-deps =
-    nose
-    coverage
-    nosexcover
+    zc.buildout


### PR DESCRIPTION
- Offer an optional `tox` part to get a local install of the `tox` testrunner.
- Setup `buildout.cfg` such that separate Python versions (tox environments) create separate scripts / interpreters.
- tox runs buildout, passing in the name of the desired environment:  that name is used to mangle filenames which would otherwise clash.
- Overrides buildouts `installed` value, so that scripts / interpreters created from one tox enviornment are not removed when running a different environment.
- N.B.:  The `coverage` environment is (temporarily) gone.  We will replace it with a version which accumulates coverage across all the other environments.
