### PR TITLE
Pin versions.cfg and versions-prod.cfg Zope's 4.x branch

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,7 @@
 [buildout]
-extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends =
+    https://zopefoundation.github.io/Zope/releases/4.x/versions-prod.cfg
+    https://zopefoundation.github.io/Zope/releases/4.x/versions.cfg
 develop = .
 parts = interpreter test
 


### PR DESCRIPTION
This fixes #24

modified:   buildout.cfg