### PR TITLE
Add badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,21 @@
+.. image:: https://travis-ci.org/zopefoundation/DateTime.svg?branch=master
+    :target: https://travis-ci.org/zopefoundation/DateTime
+
+.. image:: https://img.shields.io/pypi/v/DateTime.svg
+        :target: https://pypi.org/project/DateTime/
+        :alt: Current version on PyPI
+
+.. image:: https://img.shields.io/pypi/pyversions/DateTime.svg
+        :target: https://pypi.org/project/DateTime/
+        :alt: Supported Python versions
+
+
+DateTime
+========
+
+This package provides a DateTime data type, as known from Zope.
+
+Unless you need to communicate with Zope APIs, you're probably better
+off using Python's built-in datetime module.
+
+For further documentation, please have a look at `src/DateTime/DateTime.txt`.

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-Please refer to src/DateTime/DateTime.txt.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ import os
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(here, 'README.rst')) as f:
+    HEADER = f.read()
 with open(os.path.join(here, 'src', 'DateTime', 'DateTime.txt')) as f:
     README = f.read()
 with open(os.path.join(here, 'CHANGES.rst')) as f:
@@ -34,7 +36,12 @@ Unless you need to communicate with Zope APIs, you're probably
 better off using Python's built-in datetime module.""".replace('\n', ' '),
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
-    long_description=README + '\n\n' + CHANGES,
+    long_description = '\n\n'.join([
+        HEADER,
+        '.. contents::',
+        README,
+        CHANGES,
+    ]),
     packages=find_packages('src'),
     package_dir={'': 'src'},
     classifiers=[


### PR DESCRIPTION
In order to provide badges, a new README.rst had to be created, as
until then the `long_description` was generated by DateTime.txt, which
was used for doctests, and could not be easily moved.

Then, badges for Travis build, current version and supported Python
versions were added.

new file:   README.rst
deleted:    README.txt
modified:   setup.py

P.S.: I did a render-check via `longtest` - looks good!

This fixes #23