### PR TITLE
f-string formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.5 (unreleased)
 ----------------
 
-- Add ``__format__`` method to DateTime
+- Add ``__format__`` method for DateTime objects
   (`#35 <https://github.com/zopefoundation/DateTime/issues/35>`_)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Add __format__ method to DateTime
 
 
 4.4 (2022-02-11)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 4.5 (unreleased)
 ----------------
 
-- Add __format__ method to DateTime
+- Add ``__format__`` method to DateTime
+  (`#35 <https://github.com/zopefoundation/DateTime/issues/35>`_)
 
 
 4.4 (2022-02-11)

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -1795,6 +1795,14 @@ class DateTime(object):
             return '%4.4d/%2.2d/%2.2d %2.2d:%2.2d:%06.6f %s' % (
                 y, m, d, h, mn, s, t)
 
+    def __format__(self, fmt):
+        """Render a DateTime in an f-string."""
+        if not isinstance(fmt, str):
+            raise TypeError("must be str, not %s" % type(fmt).__name__)
+        if len(fmt) != 0:
+            return self.strftime(fmt)
+        return str(self)
+
     def __hash__(self):
         """Compute a hash value for a DateTime."""
         return int(((self._year % 100 * 12 + self._month) * 31 +

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -39,7 +39,7 @@ else:  # pragma: PY2
 
 try:
     __file__
-except NameError:
+except NameError:   # pragma: no cover
     f = sys.argv[0]
 else:
     f = __file__

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -689,6 +689,14 @@ class DateTimeTests(unittest.TestCase):
         fmt = '%-d.%-m.%Y %H:%M'
         result = dt.strftime(fmt)
         self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
+        self.assertEqual(str(dt), '{:}'.format(dt))
+        self.assertEqual(str(dt), '{}'.format(dt))
+        if sys.version_info > (3, 6, 0):  # pragma: no cover
+            eval("self.assertEqual(result, f'{dt:{fmt}}')")
+            eval("self.assertEqual(str(dt) ,f'{dt:}'.format(dt))")
+            eval("self.assertEqual(str(dt), f'{dt}'.format(dt))")
+        else:  # pragma: no cover
+            pass
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -692,12 +692,9 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
         self.assertEqual(unformatted_result, '{:}'.format(dt))
         self.assertEqual(unformatted_result, '{}'.format(dt))
-        if sys.version_info > (3, 6, 0):  # PY3
-            eval("self.assertEqual(result, f'{dt:{fmt}}')")
-            eval("self.assertEqual(unformatted_result ,f'{dt:}')")
-            eval("self.assertEqual(unformatted_result, f'{dt}')")
-        else:  # PY3
-            pass
+        eval("self.assertEqual(result, f'{dt:{fmt}}')")
+        eval("self.assertEqual(unformatted_result ,f'{dt:}')")
+        eval("self.assertEqual(unformatted_result, f'{dt}')")
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -692,11 +692,11 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
         self.assertEqual(unformatted_result, '{:}'.format(dt))
         self.assertEqual(unformatted_result, '{}'.format(dt))
-        if sys.version_info > (3, 6, 0):  # pragma: no cover
+        if sys.version_info > (3, 6, 0):  # PY3
             eval("self.assertEqual(result, f'{dt:{fmt}}')")
-            eval("self.assertEqual(unformatted_result ,f'{dt:}'.format(dt))")
-            eval("self.assertEqual(unformatted_result, f'{dt}'.format(dt))")
-        else:  # pragma: no cover
+            eval("self.assertEqual(unformatted_result ,f'{dt:}')")
+            eval("self.assertEqual(unformatted_result, f'{dt}')")
+        else:  # PY3
             pass
 
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -683,14 +683,12 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__roles__, None)
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
+    @unittest.skipUnless(PY3K, 'format method is Python 3 only')
     def test_format(self):
-        if sys.version_info > (2, 7, 0):  # pragma: no cover
-            dt = DateTime()
-            fmt = '%-d.%-m.%Y %H:%M'
-            result = dt.strftime(fmt)
-            self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
-        else:   # pragma: no cover
-            pass
+        dt = DateTime()
+        fmt = '%-d.%-m.%Y %H:%M'
+        result = dt.strftime(fmt)
+        self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -693,9 +693,9 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(unformatted_result, '{:}'.format(dt))
         self.assertEqual(unformatted_result, '{}'.format(dt))
         if sys.version_info > (3, 6, 0):  # PY3
-            self.assertEqual(result, f'{dt:{fmt}}')
-            self.assertEqual(unformatted_result, f'{dt:}')
-            self.assertEqual(unformatted_result, f'{dt}')
+            eval("self.assertEqual(result, f'{dt:{fmt}}')")
+            eval("self.assertEqual(unformatted_result ,f'{dt:}')")
+            eval("self.assertEqual(unformatted_result, f'{dt}')")
         else:  # PY3
             pass
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -684,7 +684,7 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
     def test_format(self):
-        if sys.version_info() > (2, 7, 0):
+        if sys.version_info > (2, 7, 0):
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -684,7 +684,7 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
     def test_format(self):
-        if sys.version_info > (2, 7, 0):  # pragma: PY3
+        if sys.version_info > (2, 7, 0):  # pragma: no cover
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -688,7 +688,7 @@ class DateTimeTests(unittest.TestCase):
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)
-            self.assertEqual(result, '{dt:%-d.%-m.%Y %H:%M}'.format(dt))
+            self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
         else:
             pass
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -684,7 +684,7 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
     def test_format(self):
-        if sys.version_info > (2, 7, 0):
+        if sys.version_info > (2, 7, 0):  # pragma: PY3
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -683,8 +683,8 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__roles__, None)
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
-    def test_format(self):
-        if sys.version_info > (2, 7, 0):  # pragma: no cover
+    def test_format(self):  # pragma: no cover
+        if sys.version_info > (2, 7, 0):
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -689,6 +689,8 @@ class DateTimeTests(unittest.TestCase):
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)
             self.assertEqual(result, '{dt:%-d.%-m.%Y %H:%M}'.format(dt))
+        else:
+            pass
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -684,10 +684,13 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
     def test_format(self):
-        dt = DateTime()
-        fmt = '%-d.%-m.%Y %H:%M'
-        result = dt.strftime(fmt)
-        self.assertEqual(result, f'{dt:%-d.%-m.%Y %H:%M}')
+        if sys.version_info() >= (2, 6, 0):
+            dt = DateTime()
+            fmt = '%-d.%-m.%Y %H:%M'
+            result = dt.strftime(fmt)
+            self.assertEqual(result, '{dt:%-d.%-m.%Y %H:%M}'.format(dt))
+            if sys.version_info() >= (3, 6, 0):
+                self.assertEqual(result, f'{dt:%-d.%-m.%Y %H:%M}')
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -685,16 +685,17 @@ class DateTimeTests(unittest.TestCase):
 
     @unittest.skipUnless(PY3K, 'format method is Python 3 only')
     def test_format(self):
-        dt = DateTime()
+        dt = DateTime(1968, 3, 10, 23, 45, 0, 'Europe/Vienna')
         fmt = '%-d.%-m.%Y %H:%M'
         result = dt.strftime(fmt)
+        unformatted_result = '1968/03/10 23:45:00 Europe/Vienna'
         self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
-        self.assertEqual(str(dt), '{:}'.format(dt))
-        self.assertEqual(str(dt), '{}'.format(dt))
+        self.assertEqual(unformatted_result, '{:}'.format(dt))
+        self.assertEqual(unformatted_result, '{}'.format(dt))
         if sys.version_info > (3, 6, 0):  # pragma: no cover
             eval("self.assertEqual(result, f'{dt:{fmt}}')")
-            eval("self.assertEqual(str(dt) ,f'{dt:}'.format(dt))")
-            eval("self.assertEqual(str(dt), f'{dt}'.format(dt))")
+            eval("self.assertEqual(unformatted_result ,f'{dt:}'.format(dt))")
+            eval("self.assertEqual(unformatted_result, f'{dt}'.format(dt))")
         else:  # pragma: no cover
             pass
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -693,9 +693,9 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(unformatted_result, '{:}'.format(dt))
         self.assertEqual(unformatted_result, '{}'.format(dt))
         if sys.version_info > (3, 6, 0):  # PY3
-            eval("self.assertEqual(result, f'{dt:{fmt}}')")
-            eval("self.assertEqual(unformatted_result ,f'{dt:}')")
-            eval("self.assertEqual(unformatted_result, f'{dt}')")
+            self.assertEqual(result, f'{dt:{fmt}}')
+            self.assertEqual(unformatted_result, f'{dt:}')
+            self.assertEqual(unformatted_result, f'{dt}')
         else:  # PY3
             pass
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -684,13 +684,11 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
     def test_format(self):
-        if sys.version_info() >= (2, 6, 0):
+        if sys.version_info() > (2, 7, 0):
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)
             self.assertEqual(result, '{dt:%-d.%-m.%Y %H:%M}'.format(dt))
-            if sys.version_info() >= (3, 6, 0):
-                self.assertEqual(result, f'{dt:%-d.%-m.%Y %H:%M}')
 
 
 def test_suite():

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -683,6 +683,12 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__roles__, None)
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
+    def test_format(self):
+        dt = DateTime()
+        fmt = '%-d.%-m.%Y %H:%M'
+        result = dt.strtime(fmt)
+        self.assertEqual(result, f'{dt:%-d.%-m.%Y %H:%M}')
+
 
 def test_suite():
     import doctest

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -683,13 +683,13 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(dt.__roles__, None)
         self.assertEqual(dt.__allow_access_to_unprotected_subobjects__, 1)
 
-    def test_format(self):  # pragma: no cover
-        if sys.version_info > (2, 7, 0):
+    def test_format(self):
+        if sys.version_info > (2, 7, 0):  # pragma: no cover
             dt = DateTime()
             fmt = '%-d.%-m.%Y %H:%M'
             result = dt.strftime(fmt)
             self.assertEqual(result, '{:%-d.%-m.%Y %H:%M}'.format(dt))
-        else:
+        else:   # pragma: no cover
             pass
 
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -686,7 +686,7 @@ class DateTimeTests(unittest.TestCase):
     def test_format(self):
         dt = DateTime()
         fmt = '%-d.%-m.%Y %H:%M'
-        result = dt.strtime(fmt)
+        result = dt.strftime(fmt)
         self.assertEqual(result, f'{dt:%-d.%-m.%Y %H:%M}')
 
 


### PR DESCRIPTION
Fixes #35 

added \_\_format\_\_ method to DateTime: enables formatting of the date in f-strings and with String format() (like in datetime): 

```
from DateTime import DateTime
d = DateTime()
print(f'my formatted date: {d:%d.%m.%Y}')
print('my formatted date: {d:%d.%m.%Y}'.format(d))
```
