### PR TITLE
fix round problem with addition for dates beyond 2038

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,15 @@ Changelog
 4.7 (unreleased)
 ----------------
 
+- Fix rounding problem with `DateTime` addition beyond the year 2038
+  (`#41 <https://github.com/zopefoundation/DateTime/issues/41>`_)
+
 
 4.6 (2022-09-10)
 ----------------
 
 - Fix ``__format__`` method for DateTime objects
-  (`#39 <https://github.com/zopefoundation/DateTime/issues/39>`)
+  (`#39 <https://github.com/zopefoundation/DateTime/issues/39>`_)
 
 
 4.5 (2022-07-04)

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -864,7 +864,7 @@ class DateTime(object):
         # self._micros is the time since the epoch
         # in long integer microseconds.
         if microsecs is None:
-            microsecs = long(math.floor(t * 1000000.0))
+            microsecs = long(round(t * 1000000.0))
         self._micros = microsecs
 
     def localZone(self, ltm=None):
@@ -1760,7 +1760,7 @@ class DateTime(object):
         x = _calcDependentSecond(tz, t)
         yr, mo, dy, hr, mn, sc = _calcYMDHMS(x, ms)
         return self.__class__(yr, mo, dy, hr, mn, sc, self._tz,
-                              t, d, s, None, self.timezoneNaive())
+                              t, d, s, tmicros, self.timezoneNaive())
 
     __radd__ = __add__
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -103,6 +103,16 @@ class DateTimeTests(unittest.TestCase):
         dt = DateTime()
         self.assertEqual(str(dt + 0.10 + 3.14 + 6.76 - 10), str(dt),
                          dt)
+        # checks problem reported in
+        # https://github.com/zopefoundation/DateTime/issues/41
+        dt = DateTime(2038, 10, 7, 8, 52, 44.959840, "UTC")
+        self.assertEqual(str(dt + 0.10 + 3.14 + 6.76 - 10), str(dt),
+                         dt)
+
+    def testConsistentSecondMicroRounding(self):
+        dt = DateTime(2038, 10, 7, 8, 52, 44.9598398, "UTC")
+        self.assertEqual(int(dt.second() * 1000000),
+                         dt.micros() % 60000000)
 
     def testConstructor3(self):
         # Constructor from date/time string


### PR DESCRIPTION
Fixes #41.

#41 has been caused by an inconsistent computation of `_second` and `_micros` in `_parse_args`: the first rounded to the nearest microsecond, the second floored. The PR rounds in both cases.

In addition, the PR makes `__add__` pass its computed microsecond value to the `DateTime` constructor rather than let it be recomputed in `_parse_args`.