### PR TITLE
Fix regression in 4.7 on Python 2 when calling asdatetime.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.9 (unreleased)
 ----------------
 
+- Fix regression in 4.7 on Python 2 when calling ``asdatetime``.
+  (`#47 <https://github.com/zopefoundation/DateTime/issues/47>`_)
+
 
 4.8 (2022-12-16)
 ----------------

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -680,6 +680,8 @@ class DateTime(object):
             # flag indicating whether this was constructed in a timezone naive
             # manner
             yr, mo, dy, hr, mn, sc, tz, t, d, s, microsecs, tznaive = args
+            if isinstance(microsecs, float):
+                microsecs = long(round(microsecs))
             if tznaive is not None:  # preserve this information
                 self._timezone_naive = tznaive
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -101,13 +101,17 @@ class DateTimeTests(unittest.TestCase):
     def testAddPrecision(self):
         # Precision of serial additions
         dt = DateTime()
-        self.assertEqual(str(dt + 0.10 + 3.14 + 6.76 - 10), str(dt),
-                         dt)
+        calculated_dt = dt + 0.10 + 3.14 + 6.76 - 10
+        self.assertEqual(str(calculated_dt), str(dt), dt)
         # checks problem reported in
         # https://github.com/zopefoundation/DateTime/issues/41
         dt = DateTime(2038, 10, 7, 8, 52, 44.959840, "UTC")
-        self.assertEqual(str(dt + 0.10 + 3.14 + 6.76 - 10), str(dt),
-                         dt)
+        calculated_dt = dt + 0.10 + 3.14 + 6.76 - 10
+        self.assertEqual(str(calculated_dt), str(dt), dt)
+        # checks regression on Py 2.7 where asdatetime gave an error
+        py_dt = dt.asdatetime()
+        py_calculated_dt = calculated_dt.asdatetime()
+        self.assertEqual(py_dt, py_calculated_dt)
 
     def testConsistentSecondMicroRounding(self):
         dt = DateTime(2038, 10, 7, 8, 52, 44.9598398, "UTC")


### PR DESCRIPTION
Fixes https://github.com/zopefoundation/DateTime/issues/47.
Note that this PR targets the new branch 4.x. See my comment in that issue.