### PR TITLE
Cast int to float in compare methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Cast int to float in compare methods.
 
 
 5.1 (2023-03-14)

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -1249,12 +1249,10 @@ class DateTime:
         """
         if t is None:
             t = 0
-        if isinstance(t, float):
+        if isinstance(t, (float, int)):
             return self._micros > long(t * 1000000)
-        try:
+        else:
             return self._micros > t._micros
-        except AttributeError:
-            return self._micros > t
 
     __gt__ = greaterThan
 
@@ -1272,12 +1270,10 @@ class DateTime:
         """
         if t is None:
             t = 0
-        if isinstance(t, float):
+        if isinstance(t, (float, int)):
             return self._micros >= long(t * 1000000)
-        try:
+        else:
             return self._micros >= t._micros
-        except AttributeError:
-            return self._micros >= t
 
     __ge__ = greaterThanEqualTo
 
@@ -1294,12 +1290,10 @@ class DateTime:
         """
         if t is None:
             t = 0
-        if isinstance(t, float):
+        if isinstance(t, (float, int)):
             return self._micros == long(t * 1000000)
-        try:
+        else:
             return self._micros == t._micros
-        except AttributeError:
-            return self._micros == t
 
     def notEqualTo(self, t):
         """Compare this DateTime object to another DateTime object
@@ -1341,12 +1335,10 @@ class DateTime:
         """
         if t is None:
             t = 0
-        if isinstance(t, float):
+        if isinstance(t, (float, int)):
             return self._micros < long(t * 1000000)
-        try:
+        else:
             return self._micros < t._micros
-        except AttributeError:
-            return self._micros < t
 
     __lt__ = lessThan
 
@@ -1363,12 +1355,10 @@ class DateTime:
         """
         if t is None:
             t = 0
-        if isinstance(t, float):
+        if isinstance(t, (float, int)):
             return self._micros <= long(t * 1000000)
-        try:
+        else:
             return self._micros <= t._micros
-        except AttributeError:
-            return self._micros <= t
 
     __le__ = lessThanEqualTo
 

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -217,6 +217,23 @@ class DateTimeTests(unittest.TestCase):
         self.assertTrue(dt.lessThanEqualTo(dt1))
         self.assertTrue(dt.notEqualTo(dt1))
         self.assertFalse(dt.equalTo(dt1))
+        # Compare a date to float
+        dt = DateTime(1.0)
+        self.assertFalse(dt.greaterThan(1.0))
+        self.assertTrue(dt.greaterThanEqualTo(1.0))
+        self.assertFalse(dt.lessThan(1.0))
+        self.assertTrue(dt.lessThanEqualTo(1.0))
+        self.assertFalse(dt.notEqualTo(1.0))
+        self.assertTrue(dt.equalTo(1.0))
+        # Compare a date to int
+        dt = DateTime(1)
+        self.assertEqual(dt, DateTime(1.0))
+        self.assertFalse(dt.greaterThan(1))
+        self.assertTrue(dt.greaterThanEqualTo(1))
+        self.assertFalse(dt.lessThan(1))
+        self.assertTrue(dt.lessThanEqualTo(1))
+        self.assertFalse(dt.notEqualTo(1))
+        self.assertTrue(dt.equalTo(1))
 
     def test_compare_methods_none(self):
         # Compare a date to None


### PR DESCRIPTION
As `DateTime(int)` behaviour is same as `DateTime(float)`, we expect `equalTo(int)` behaviour same as `equalTo(float)` and same for other compare methods as well.

FYI, the coverate rate becomes a bit worse with this change but it is just because `src/DateTime/DateTime.py` has less number of lines, i.e. the number of non-covered lines does not increase.