### PR TITLE
Change pickle format to export the micros as int

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changelog
 
 - Nothing changed yet.
 
-- Change pickle format to export the milliseconds as an int, to
+- Change pickle format to export the microseconds as an int, to
   solve a problem with dates after 2038.
   (`#56 <https://github.com/zopefoundation/DateTime/issues/56>`_)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@ Changelog
 
 - Nothing changed yet.
 
+- Change pickle format to export the milliseconds as an int, to
+  solve a problem with dates after 2038.
+  (`#56 <https://github.com/zopefoundation/DateTime/issues/56>`_)
+
 
 5.4 (2023-12-15)
 ----------------

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -455,7 +455,7 @@ class DateTime:
             micros, tz_naive, tz = value
             if isinstance(micros, float):
                 # BBB: support for pickle where micros was a float
-                micros = long(micros * 1000000)
+                micros = int(micros * 1000000)
             self._parse_args(micros / 1000000., tz)
             self._micros = micros
             self._timezone_naive = tz_naive

--- a/src/DateTime/DateTime.py
+++ b/src/DateTime/DateTime.py
@@ -446,17 +446,19 @@ class DateTime:
             raise SyntaxError('Unable to parse {}, {}'.format(args, kw))
 
     def __getstate__(self):
-        # We store a float of _micros, instead of the _micros long, as we most
-        # often don't have any sub-second resolution and can save those bytes
-        return (self._micros / 1000000.0,
+        return (self._micros,
                 getattr(self, '_timezone_naive', False),
                 self._tz)
 
     def __setstate__(self, value):
         if isinstance(value, tuple):
-            self._parse_args(value[0], value[2])
-            self._micros = long(value[0] * 1000000)
-            self._timezone_naive = value[1]
+            micros, tz_naive, tz = value
+            if isinstance(micros, float):
+                # BBB: support for pickle where micros was a float
+                micros = long(micros * 1000000)
+            self._parse_args(micros / 1000000., tz)
+            self._micros = micros
+            self._timezone_naive = tz_naive
         else:
             for k, v in value.items():
                 if k in self.__slots__:

--- a/src/DateTime/tests/test_datetime.py
+++ b/src/DateTime/tests/test_datetime.py
@@ -338,6 +338,24 @@ class DateTimeTests(unittest.TestCase):
         for key in DateTime.__slots__:
             self.assertEqual(getattr(dt, key), getattr(new, key))
 
+    def test_pickle_dates_after_2038(self):
+        dt = DateTime('2039/09/02 07:07:6.235027 GMT+1')
+        data = pickle.dumps(dt, 1)
+        new = pickle.loads(data)
+        for key in DateTime.__slots__:
+            self.assertEqual(getattr(dt, key), getattr(new, key))
+
+    def test_pickle_old_with_micros_as_float(self):
+        dt = DateTime('2002/5/2 8:00am GMT+0')
+        data = (
+            'ccopy_reg\n_reconstructor\nq\x00(cDateTime.DateTime\nDateTime'
+            '\nq\x01c__builtin__\nobject\nq\x02Ntq\x03Rq\x04(GA\xcehy\x00\x00'
+            '\x00\x00I00\nX\x05\x00\x00\x00GMT+0q\x05tq\x06b.')
+        data = data.encode('latin-1')
+        new = pickle.loads(data)
+        for key in DateTime.__slots__:
+            self.assertEqual(getattr(dt, key), getattr(new, key))
+
     def testTZ2(self):
         # Time zone manipulation test 2
         dt = DateTime()


### PR DESCRIPTION
During pickle serialization, the `_micros` attribute was casted to float,
to save a little bit of disk space by making shorter pickles, this was
true when ZODB was using pickle protocol 1, but nowadays it uses protocol 3
and exporting as an int produces pickles of the same length as with a float.

Fixes #56
